### PR TITLE
[FIX] stock_picking_group_by_partner_by_carrier: add a hook to handle domain on move_type

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -37,6 +37,13 @@ class StockMove(models.Model):
         )
         return picking
 
+    def _domain_search_picking_handle_move_type(self):
+        """Hook to handle the move type. Can be overloaded by other modules.
+        By default the move type is taken from the procurement group.
+        """
+        # avoid mixing picking policies
+        return [("move_type", "=", self.group_id.move_type)]
+
     def _domain_search_picking_for_assignation(self):
         states = ("draft", "confirmed", "waiting", "partially_available", "assigned")
         if (
@@ -51,10 +58,9 @@ class StockMove(models.Model):
             domain = [
                 # same partner
                 ("partner_id", "=", self.group_id.partner_id.id),
-                # avoid mixing picking policies
-                ("move_type", "=", self.group_id.move_type),
                 # don't search on the procurement.group
             ]
+            domain += self._domain_search_picking_handle_move_type()
             # same carrier only for outgoing transfers
             if self.picking_type_id.code == "outgoing":
                 domain += [


### PR DESCRIPTION
And add a test with the 'pick_pack_ship' configuration with grouping enabled on pack+ship (but not pick).